### PR TITLE
advent of code

### DIFF
--- a/day2_part2.py
+++ b/day2_part2.py
@@ -1,0 +1,33 @@
+file_path = "/venvs/adventofcode_2.txt"
+with open(file_path) as f:
+    line = f.read().splitlines()
+
+lst = []
+for i in line:
+    lst.append(i.split(": "))
+
+dict = {}
+for idx, i in enumerate(lst):
+    value = i[0].split()
+    dict[idx] = [i[1], list(map(int, value[0].split("-"))), value[1]]
+
+
+count = 0
+
+for key, value in dict.items():
+    first_position_letter = value[0][value[1][0] - 1]
+    second_position_letter = value[0][value[1][1] - 1]
+    given_letter = value[2]
+
+    # if first_position_letter == given_letter:
+    #     if not second_position_letter == given_letter:
+    #         count += 1
+    # elif second_position_letter == given_letter:
+    #     count += 1
+
+    if first_position_letter == given_letter and not second_position_letter == given_letter:
+        count += 1
+    elif second_position_letter == given_letter and not first_position_letter == given_letter:
+        count += 1
+print(count)
+


### PR DESCRIPTION
day2 part2 주석처리한 부분이 나을까요 아니면 and를 쓴게 나을까요?

문제

Each policy actually describes two positions in the password, where 1 means the first character, 2 means the second character, and so on. (Be careful; Toboggan Corporate Policies have no concept of "index zero"!) Exactly one of these positions must contain the given letter. Other occurrences of the letter are irrelevant for the purposes of policy enforcement.

Given the same example list from above:

1-3 a: abcde is valid: position 1 contains a and position 3 does not.
1-3 b: cdefg is invalid: neither position 1 nor position 3 contains b.
2-9 c: ccccccccc is invalid: both position 2 and position 9 contain c.
How many passwords are valid according to the new interpretation of the policies?